### PR TITLE
Fix setAngle bug

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
         "quotes": ["error", "double"],
         "no-underscore-dangle": 0,
         "no-console": 0,
-        "prefer-destructuring": 0
+        "prefer-destructuring": 0,
+        "no-mixed-operators": 0,
     }
 };

--- a/src/demo.js
+++ b/src/demo.js
@@ -2,7 +2,7 @@ const CircleSlider = require("./index.js");
 
 const options = {
   snap: 45,
-  clockwise: true,
+  clockwise: false,
   startPos: "right",
 };
 const cs = new CircleSlider("#slider", options);

--- a/src/index.js
+++ b/src/index.js
@@ -84,8 +84,15 @@ class CircleSlider extends EventEmitter {
    * @memberof CircleSlider
    */
   setAngle(angle) {
-    const rawAngle = this._formatOutputAngle(angle);
+    const rawAngle = this._formatInputAngle(angle);
     this._moveHandle(rawAngle);
+  }
+
+  _formatInputAngle(angle) {
+    const rawAngle = this.clockwise === true ?
+      CircleSlider.modulo((Math.round(angle) - 360 + this.startOffset), 360) :
+      CircleSlider.modulo((360 - Math.round(angle) + this.startOffset), 360);
+    return rawAngle;
   }
 
   // "private" methods


### PR DESCRIPTION
This PR fixes the issue where the setAngle function would set the wrong values for `startPos: "top", clockwise: true` and `startPos: "bottom", clockwise: false`.