### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -165,13 +165,20 @@ class CircleSlider extends EventEmitter {
 
   _getRawAngle(e) {
     const pivot = CircleSlider._getCenter(this.root);
-    const mouse = {
-      x: e.pageX,
-      y: e.pageY,
-    };
+    let mouse;
+    if (e.type == 'touchmove') {
+      mouse = {
+        x: e.touches[0].clientX,
+        y: e.touches[0].clientY,
+      };
+    } else {
+      mouse = {
+        x: e.clientX,
+        y: e.clientY,
+      };
+    }
 
-    const angle = (CircleSlider._radToDeg(Math.atan2(mouse.y - pivot.y, mouse.x - pivot.x))
-    ) % 360;
+    const angle = (CircleSlider._radToDeg(Math.atan2(mouse.y - pivot.y, mouse.x - pivot.x))) % 360;
     return angle;
   }
 


### PR DESCRIPTION
fixed bug on android devices or devices using touch events. references issue #3:  https://github.com/willwull/circle-slider/issues/3
Note: pageX & pageY has been changed to clientX & clientY for better compatibility and performance. using pageX& pageY causes  slider handle movement glitches.